### PR TITLE
Exit if git is not present

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,12 @@ Git.commands = [];
  * @type {String}
  * @public
  */
-Git.path = shelly.which('git').stdout;
+try {
+  Git.path = shelly.which('git').stdout;
+} catch (e) {
+  shelly.echo('This environment does not have a git binary');
+  shelly.exit(0);
+}
 
 //
 // This is where all the magic happens. We're going to extract all the commands


### PR DESCRIPTION
In some environments, like `docker` containers, the `git` binary may not by present. So instead we exit right away to avoid installation errors. This is recommended by [`shelljs`' examples](https://www.npmjs.com/package/shelljs#examples)